### PR TITLE
fix/Make Q logo and question text black

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -29,7 +29,7 @@
   left: 20px;
   font-weight: bold;
   color: #FFF;/*文字色*/
-  background: #FF72D0;
+  background: #000000;//#FF72D0;
   border-radius: 5px;/*角の丸み*/
 }
 
@@ -47,7 +47,7 @@
 
 .question_detail_strings
 {
-  color: #FF72D0;
+  color: #000000;//#FF72D0;
   line-height: 1.5;
 }
 
@@ -148,7 +148,7 @@
   left: 20px;
   font-weight: bold;
   color: #FFF;/*文字色*/
-  background: #FF72D0;
+  background: #000000;//#FF72D0;
   border-radius: 5px;/*角の丸み*/
 }
 
@@ -166,7 +166,7 @@
 
 .question_detail_strings
 {
-  color: #FF72D0;
+  color: #000000;//#FF72D0;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
## やったこと

よくある質問の「Q]のロゴの背景色を黒にする。質問のテキストを黒にする。

## やらないこと

無し。

## できるようになること（ユーザ目線）

よくある質問の見た目が変わる。

## できなくなること（ユーザ目線）

無し。

## 動作確認

questions/index.html.erbの表示確認。スマホサイズにしたときも同様にquestions/index.html.erbの表示を確認しました。

## その他

中野さんからの依頼で修正しました。