### PR TITLE
マップにサブスク表示制限範囲を設定

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
+  before_action :map_object, only: %i(top)
 
   def top
     @blogs = Blog.all
@@ -6,12 +7,7 @@ class StaticPagesController < ApplicationController
     @questions = Question.all
     @interviews = Interview.where.not(shop_name: nil)
     @megurumereviews = Megurumereview.all
-    if params[:map].present? && params[:map][:address].present?
-      results = Geocoder.search(params[:map][:address])
-      @latlng = results.first.geometry
-    end
     @owners = Owner.all
-    gon.subscriptions = Subscription.all
     @categories_name = Category.where.not(name: nil)#検索機能が選択ボックスだったら使う
     @categories = if params[:search]
       Category.search(params[:search]).order("RAND()").limit(6)
@@ -24,8 +20,6 @@ class StaticPagesController < ApplicationController
     @blogs = Blog.all
     @interviews = Interview.where.not(shop_name: nil)
     @questions = Question.all
-    results = Geocoder.search(params[:address])
-    @latlng = results.first
     @categories_name = Category.where.not(name: nil)#検索機能が選択ボックスだったら使う
     @categories = if params[:search]
       Category.search(params[:search]).order("RAND()").limit(6)
@@ -41,6 +35,20 @@ class StaticPagesController < ApplicationController
   end
 
   def specified_commercial_transaction_law
+  end
+
+  def map_object
+    if params[:map].present? && params[:map][:address].present?
+      results = Geocoder.search(params[:map][:address])
+      @latlng = results.first.geometry
+      top = @latlng["location"]["lng"] + 0.2
+      bottom = @latlng["location"]["lng"] - 0.2
+      left = @latlng["location"]["lat"] + 0.2
+      right = @latlng["location"]["lat"] - 0.2
+      gon.subscriptions = Subscription.where(longitude: bottom..top).where(latitude: right..left)
+    else
+      gon.subscriptions = Subscription.where(longitude: 139.5..139.9).where(latitude: 35.4..35.8)
+    end
   end
 
   private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,8 +126,6 @@ Subscription.create!(
   image_subscription4: "soba.jpeg",
   image_subscription5: "soba.jpeg",
   address: "東京都渋谷区富ヶ谷1丁目",
-  latitude: 35.659020,
-  longitude: 139.702233
 )
 
 Subscription.create!(
@@ -146,8 +144,6 @@ Subscription.create!(
   image_subscription4: "soba.jpeg",
   image_subscription5: "soba.jpeg",
   address: "東京都渋谷区富ヶ谷2丁目",
-  latitude: 35.658096,
-  longitude: 139.700466
 )
 
 Subscription.create!(
@@ -166,8 +162,6 @@ Subscription.create!(
   image_subscription4: "soba.jpeg",
   image_subscription5: "soba.jpeg",
   address: "東京都渋谷区富ヶ谷3丁目",
-  latitude: 35.658096,
-  longitude: 139.700466
 )
 
 puts "Subscription Created"


### PR DESCRIPTION
## やったこと
マップに一定範囲を設定し、範囲内のサブスクのみを表示するように設定

## できなくなること（ユーザ目線）
全件取得することがなくなります。

## 動作確認
dev環境にて動作確認

## その他
seedファイルで座標を設定しても住所から自動で座標を取得できるようなので削除しました。
レビューよろしくお願いします。
