### PR TITLE
SMS認証機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
+gem 'phony_rails' # 電話番号
+gem 'twilio-ruby'
 
 group :development, :test do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,10 @@ GEM
     paranoia (2.4.3)
       activerecord (>= 4.0, < 6.2)
     pg (0.20.0)
+    phony (2.18.19)
+    phony_rails (0.14.13)
+      activesupport (>= 3.0)
+      phony (> 2.15)
     popper_js (1.16.0)
     public_suffix (4.0.6)
     puma (3.12.6)
@@ -322,6 +326,10 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    twilio-ruby (5.47.0)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -385,6 +393,7 @@ DEPENDENCIES
   owlcarousel-rails
   paranoia (~> 2.3, >= 2.3.1)
   pg (= 0.20.0)
+  phony_rails
   puma (~> 3.7)
   rails (~> 5.1.6)
   rails-controller-testing
@@ -400,6 +409,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   stripe
+  twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,12 +52,20 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # ユーザー削除時orプラン解除時
   # ログイン中のユーザーが何かしらのプランに加入していた場合支払いを停止する
   def payment_planning_delete
     if current_user.customer_id.present?
       @payment = Stripe::Checkout::Session.retrieve(current_user.customer_id)
       Stripe::Subscription.delete(@payment.subscription)
       current_user.update!(customer_id: "")
+    end
+  end
+
+  # 未認証ならトップページにリダイレクトされる。
+  def sms_auth_false?
+    unless current_user.sms_auth?
+      redirect_to sms_auth_users_url
     end
   end
 end

--- a/app/controllers/concerns/random_value_generator.rb
+++ b/app/controllers/concerns/random_value_generator.rb
@@ -1,0 +1,9 @@
+module RandomValueGenerator
+  extend ActiveSupport::Concern
+
+  require "securerandom"
+
+  def random_number_generator(n)
+    ''.tap { |s| n.times { s << rand(0..9).to_s } }
+  end
+end

--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -1,0 +1,48 @@
+class SmsController < ApplicationController
+  before_action :authenticate_user!, :sms_auth_true?
+
+  include RandomValueGenerator
+
+  require 'twilio-ruby'
+
+  #SMSの送信
+  def new
+    send_phone_number = PhonyRails.normalize_number current_user.phone_number, country_code:'JP'
+    session[:secure_code] = random_number_generator(6)
+
+    # twilioのMessagingAPIを使用してSMSに認証コード送信
+    begin
+      client = Twilio::REST::Client.new(ENV["TWILIO_ACCOUNT_SID"], ENV["TWILIO_AUTH_TOKEN"])
+      result = client.messages.create(
+        from: ENV["TWILIO_PHONE_NUMBER"],
+        to: send_phone_number,
+        body: "認証番号：#{session[:secure_code]} この番号を巡グルメの画面で入力してください。"
+      )
+    rescue Twilio::REST::RestError => e
+      @messages = "エラーコード[#{e.code}] ：” #{e.message}”"
+    end
+  end
+
+  # 入力チェック
+  def confirm
+    if params[:secure_code].present?
+      if session[:secure_code] == params[:secure_code]
+        current_user.update!(sms_auth: true)
+        redirect_to new_user_plan_url
+      else
+        @messages = '認証番号が一致しませんでした'
+        render root_url
+      end
+    else
+      @messages = '認証番号を入力してください'
+      render root_url
+    end
+  end
+
+  # すでに認証済みならプラン選択画面に遷移
+  def sms_auth_true?
+    if current_user.sms_auth?
+      redirect_to new_user_plan_url
+    end
+  end
+end

--- a/app/controllers/user_plans_controller.rb
+++ b/app/controllers/user_plans_controller.rb
@@ -5,6 +5,8 @@ class UserPlansController < ApplicationController
   before_action :authenticate_user!
   before_action :payment_check, only: %i(new edit confirm update_confirm update destroy)
   before_action :payment_planning_delete, only: :destroy
+  before_action :sms_auth_false?, only: %i(new confirm destroy)
+
   # stripe決済成功時
   def success
     current_user.update!(customer_id: current_user.session_id, session_id: "")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,8 +12,9 @@ class UsersController < ApplicationController
 
   def user_edit_update
     if @user.update_attributes(user_params)
+      @user.update!(sms_auth: false) if @user.phone_number_changed?
       flash[:success] = "#{@user.name}様の情報を更新しました。"
-      redirect_to user_account_user_url(current_user)
+      redirect_to @user
     else
       render :user_edit
     end
@@ -79,7 +80,6 @@ class UsersController < ApplicationController
     end
   end
 
-
   private
 
     def set_user
@@ -89,6 +89,4 @@ class UsersController < ApplicationController
     def user_params
       params.require(:user).permit(:name, :kana, :email, :phone_number, :address, :password, :password_confirmation)
     end
-
-
 end

--- a/app/views/categories/recommend.html.erb
+++ b/app/views/categories/recommend.html.erb
@@ -17,7 +17,7 @@
       <div class="col-lg-7 col-xl-8">
         <h4 class="font-weight-bold mb-3"><strong><%= subscription.name %></strong></h4>
         <p class="dark-grey-text"><%= subscription.title %></p>
-        <%= link_to "サブスクしてみる", owner_subscription_path(id: subscription.id, owner_id: subscription.owner_id, shop_id: subscription.shop_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
+        <%= link_to "サブスクしてみる", owner_subscription_path(id: subscription.id, owner_id: subscription.owner_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
       </div>
     </div>
     <hr class="my-3">

--- a/app/views/sms/new.html.erb
+++ b/app/views/sms/new.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(url: sms_auth_users_path, local: true) do |f| %>
+  <%= f.label "確認コード" %>
+  <%= f.text_field :secure_code %>
+
+  <%= f.submit "確認" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,15 +117,11 @@ Rails.application.routes.draw do
   end
   get 'users/deleted_users'##論理削除された利用者
   resources :users do
-    resources :user_plans do
-      get "confirm", to: "user_plans#confirm"
-      get "update_confirm", to: "user_plans#update_confirm"
-      get 'new', to: "user_plans#new", as: 'plans_new' #利用者のプラン内容
-      get "edit", to: "user_plans#edit", as: 'plans_edit'
-      patch "update", to: "user_plans#update", as: 'plans_update'
-      delete "destroy", to: "user_plans#destroy", as: 'plans_destroy'
+    collection do
+      get :search # ユーザーの名前であいまい検索 追加分
+      get "sms_auth", to: "sms#new"
+      post "sms_auth", to: "sms#confirm"
     end
-    get :search, on: :collection # ユーザーの名前であいまい検索 追加分
     get 'user_edit', on: :member#
     patch 'user_edit_update', on: :member#
     resources :tickets#サブスクチケット

--- a/db/migrate/20201112230700_devise_create_users.rb
+++ b/db/migrate/20201112230700_devise_create_users.rb
@@ -26,6 +26,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
       t.string :subject
       t.string :session_id
       t.integer :subscription_id
+      t.boolean :sms_auth, null: false, default: false
       t.string :customer_id, null: false, default: ""
       t.date :use_ticket_day
       t.date :issue_ticket_day

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,6 +283,7 @@ ActiveRecord::Schema.define(version: 20210218075622) do
     t.string "subject"
     t.string "session_id"
     t.integer "subscription_id"
+    t.boolean "sms_auth", default: false, null: false
     t.string "customer_id", default: "", null: false
     t.date "use_ticket_day"
     t.date "issue_ticket_day"


### PR DESCRIPTION
## やったこと
・SMS認証機能実装(Twilioに登録)
・コントローラ、Userにカラム追加
## やらないこと
アクセス制限系
## できるようになること（ユーザ目線）
プラン選択前にユーザーが登録した電話番号にSMSを送信し、番号入力でプラン選択画面を正しく表示される。

## できなくなること（ユーザ目線）
SMS認証をしないとサブスクを登録できない
## 動作確認
devにて手動確認をしました

## その他
SMS認証を実際動かすにはTwilioに登録する必要があります。(無料)
コードレビューよろしくお願いします。