### PR TITLE
Feature/チケット履歴のオーナー名とオーナーEmailが正しく表示されるように修正

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -16,9 +16,9 @@ class CategoriesController < ApplicationController
   def like_lunch
     #@subscriptions = @category.subscriptions
     @categories = Category.find(params[:id])
-    @subscription = Subscription.find_by(params[:id])
-    @private_store = PrivateStore.find_by(params[:id])
-    @owner = Owner.find(params[:id])
+    #@subscription = Subscription.find_by(params[:id])
+    #@private_store = PrivateStore.find_by(params[:id])
+    #@owner = Owner.find(params[:id])
   end
 
   def create

--- a/app/controllers/private_store_users_controller.rb
+++ b/app/controllers/private_store_users_controller.rb
@@ -57,8 +57,9 @@ class PrivateStoreUsersController < ApplicationController
   end
 
   def ticket
-    @owner = Owner.find(params[:id])
+    #@owner = Owner.find(params[:id])
     @private_store = PrivateStore.find(params[:id])
+    @owner = Owner.find(@private_store.owner_id)
   end
 
   # ユーザーの名前をあいまい検索機能

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,8 +57,9 @@ class UsersController < ApplicationController
   end
 
   def ticket
-    @owner = Owner.find(params[:id])
+    #@owner = Owner.find(params[:id])
     @subscription = Subscription.find(params[:id])
+    @owner = Owner.find(@subscription.owner_id)
   end
 
   # ユーザーの名前をあいまい検索機能

--- a/app/views/categories/like_lunch.html.erb
+++ b/app/views/categories/like_lunch.html.erb
@@ -21,7 +21,7 @@
 	<span class="badge badge-success">加盟店</span>
         <h4 class="font-weight-bold mb-3"><strong><%= category_subscription.subscription.name %></strong></h4>
         <p class="dark-grey-text"><%= category_subscription.subscription.title %></p>
-        <%= link_to "サブスクしてみる", owner_subscription_path(category_subscription.subscription.id, owner_id: @subscription.owner_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
+        <%= link_to "サブスクしてみる", owner_subscription_path(category_subscription.subscription.id, owner_id: category_subscription.subscription.owner_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
       </div>
     </div>
     <hr class="my-3">
@@ -45,7 +45,7 @@
 	<span class="badge badge-primary">個人店舗</span>
         <h4 class="font-weight-bold mb-3"><strong><%= category_private_store.private_store.name %></strong></h4>
         <p class="dark-grey-text"><%= category_private_store.private_store.title %></p>
-        <%= link_to "サブスクしてみる", owner_private_store_path(category_private_store.private_store.id, owner_id: @private_store.owner_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
+        <%= link_to "サブスクしてみる", owner_private_store_path(category_private_store.private_store.id, owner_id: category_private_store.private_store.owner_id), class: 'btn btn-outline-primary btn-rounded text-primary' %>
       </div>
     </div>
     <hr class="my-3">

--- a/app/views/private_stores/show.html.erb
+++ b/app/views/private_stores/show.html.erb
@@ -36,10 +36,10 @@
                   <% end %>
               <% if @payment.present? %>
                 <% if @private_store.price.to_i < current_user.user_price %>
-                  <%= link_to "チケットを使う", private_store_use_ticket_path(@private_store, @owner, owner_id: @private_store.owner_id), class: "btn-gradient-3d-simple" %>
+                  <%= link_to "チケットを使う", private_store_use_ticket_path(@private_store), class: "btn-gradient-3d-simple" %>
                   <%= link_to "サブスクを解除する", user_plan_path, method: :delete, data: { confirm: "【確認】サブスクを解除してよろしいでしょうか？" }, class: "btn-gradient-3d-simple" %>
                 <% elsif @private_store.price.to_i == current_user.user_price %>
-                  <%= link_to "チケットを使う", private_store_use_ticket_path(@private_store, @owner, owner_id: @private_store.owner_id), class: "btn-gradient-3d-simple" %>
+                  <%= link_to "チケットを使う", private_store_use_ticket_path(@private_store), class: "btn-gradient-3d-simple" %>
                   <%= link_to "サブスクを解除する", user_plan_path, method: :delete, data: { confirm: "【確認】サブスクを解除してよろしいでしょうか？" }, class: "btn-gradient-3d-simple" %>
                 <% else %>
                   <%= link_to "プランを変更する", edit_user_plan_path, class: "btn-gradient-3d-simple" %>

--- a/app/views/subscriptions/show.html.erb
+++ b/app/views/subscriptions/show.html.erb
@@ -36,9 +36,9 @@
                   <% end %>
               <% if @payment.present? %>
                 <% if current_user.user_price  === 1000%>
-                  <%= link_to "チケットを使う", use_ticket_path(@subscription, @owner, owner_id: @subscription.owner_id), class: "btn-gradient-3d-simple" %>
+                  <%= link_to "チケットを使う", use_ticket_path(@subscription), class: "btn-gradient-3d-simple" %>
                 <% elsif @subscription.price.to_i < current_user.user_price %>
-                  <%= link_to "チケットを使う", use_ticket_path(@subscription, @owner, owner_id: @subscription.owner_id), class: "btn-gradient-3d-simple" %>
+                  <%= link_to "チケットを使う", use_ticket_path(@subscription), class: "btn-gradient-3d-simple" %>
                   <%= link_to "サブスクを解除する", user_plan_path, method: :delete, data: { confirm: "【確認】サブスクを解除してよろしいでしょうか？" }, class: "btn-gradient-3d-simple" %>
                 <% elsif @subscription.price.to_i == current_user.user_price %>
                   <%= link_to "チケットを使う", use_ticket_path(@subscription, @owner, owner_id: @subscription.owner_id), class: "btn-gradient-3d-simple" %>


### PR DESCRIPTION
## やったこと

チケット履歴のオーナー名とオーナーEmailが正しく表示されるように修正

## やらないこと

「サブスクを解除する」ボタンを押したときのエラー修正

## できるようになること（ユーザ目線）

正しいチケット履歴が見れるようになった。

## できなくなること（ユーザ目線）

無し。

## 動作確認

チケット発行から使用、チケット履歴表示まで、加盟店と個人店で確認しました。

## その他

引き続き、「サブスクを解除する」ボタンを押したときのエラー修正に取り組みます。