### PR TITLE
adminnのチケット使用履歴ボタンを１つ削除と電話番号バリデーション追加

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -28,9 +28,11 @@ class Owner < ApplicationRecord
   validates_format_of :email, presence: true, with: Devise.email_regexp, if: :will_save_change_to_email?
   validates :password, presence: true, confirmation: true, length: { in: Devise.password_length }, on: :create
   validates :password, confirmation: true, length: { in: Devise.password_length }, allow_blank: true, on: :update
+  VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
+  validates :phone_number, presence: true, format: { with: VALID_PHONE_REGEX }
   # validate :owner_password_regex, on: :create
   # validate :owner_phone_number_regex
-
+  
   # パスワードバリデーションメソッド
   def owner_password_regex
     if password !~ /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,128}+\z/i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ApplicationRecord
   validates :password, presence: true, confirmation: true, length: { in: Devise.password_length }, on: :create # 6..128
   validates :password, confirmation: true, length: { in: Devise.password_length }, allow_blank: true, on: :update
   validate :user_password_regex, on: :create
+  VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
+  validates :phone_number, presence: true, format: { with: VALID_PHONE_REGEX }
 
   # パスワードバリデーションメソッド
   def user_password_regex

--- a/app/views/admins/account.html.erb
+++ b/app/views/admins/account.html.erb
@@ -29,9 +29,7 @@
   <div class="account-btn">
     <%= link_to "編集", edit_admin_path, class: "btn-gradient-3d-simple" %>
   </div></br>
-  <div class="account-btn">
-    <%= link_to "チケット使用履歴", user_tickets_path(current_admin), class: "btn-gradient-3d-simple" %>
-  </div></br>
+
   <% if current_admin.present? %>
     <%= link_to "チケット使用履歴", ticket_logs_path, class: "btn-gradient-3d-simple" %>
   <% end %>

--- a/app/views/owners/registrations/new.html.erb
+++ b/app/views/owners/registrations/new.html.erb
@@ -18,7 +18,7 @@
       </div>
 
       <div class="field">
-        <%= f.label :phone_number %> <span>(ハイフンなし)連絡がつきやすい番号でお願いします。</span><span class="must">必須</span><br/>
+        <%= f.label :phone_number %> <span>＊(ハイフンなし)連絡がつきやすい番号でお願いします。</span><span class="must">必須</span><br/>
         <%= f.telephone_field :phone_number, :required => true, class: 'form-control' %>
       </div>
 
@@ -39,7 +39,7 @@
         <% if @minimum_password_length %>
         <em>(最小<%= @minimum_password_length %>文字)</em>
         <% end %><br/>
-        <%= f.password_field :password, :required => true,autocomplete: "new-password", class: 'form-control' %>
+        <%= f.password_field :password, placeholder: "6文字以上、半角数字と半角英字を使用", :required => true,autocomplete: "new-password", class: 'form-control' %>
       </div>
 
       <% if resource.errors.include?(:password) %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -18,7 +18,7 @@
       </div>
 
       <div class="field">
-        <%= f.label :phone_number, class: "form-label" %><span class="must">必須</span>
+        <%= f.label :phone_number, class: "form-label" %><span class="must">必須</span><span>＊ハイフンなし</span>
         <%= f.text_field :phone_number, class: "form-control" %>
       </div>
 
@@ -27,7 +27,7 @@
         <% if @minimum_password_length %>
         <em>(最小<%= @minimum_password_length %>文字)</em>
         <% end %><br/>
-        <%= f.password_field :password, :required => true,autocomplete: "new-password", class: 'form-control' %>
+        <%= f.password_field :password, :required => true, placeholder: "6文字以上、半角英字と半角数字を使用", autocomplete: "new-password", class: 'form-control' %>
       </div>
 
       <% if resource.errors.include?(:password) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210306142407) do
+ActiveRecord::Schema.define(version: 20210306095519) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -153,7 +153,6 @@ ActiveRecord::Schema.define(version: 20210306142407) do
     t.string "provider"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "info"
     t.index ["email"], name: "index_owners_on_email", unique: true
     t.index ["reset_password_token"], name: "index_owners_on_reset_password_token", unique: true
   end
@@ -368,7 +367,6 @@ ActiveRecord::Schema.define(version: 20210306142407) do
     t.integer "session_price"
     t.integer "private_store_id"
     t.datetime "deleted_at"
-    t.string "info"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## やったこと

・利用者、経営者のアカウント新規作成フォームに条件を表示。
・管理者のアカウントページにあるチケット使用履歴ボタンが２つあるので１つ削除
・利用者、経営者のアカウント新規作成時の電話番号バリデーション追加（ハイフンなし半角数字１０文字or11文字）
## やらないこと

* このプルリクでやらないことは何か？なし

## できるようになること（ユーザ目線）

* 何ができるようになるのか？
利用者、経営者のアカウント新規作成フォームでハイフンなしなど条件がわかる

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
ローカルブラウザで表示確認　OK

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）