### PR TITLE
Fix/sns sign up mail to admin　3回目　（最新）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -56,7 +56,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         sign_in(:user, @profile)
         # redirect_to edit_user_path(@profile.user.id) and return
         UserMailer.with(user: @user).welcome_email.deliver_now
-        UserMailer.with(user: @user).notice_user_joining_email.deliver_now
+        UserMailer.with(user: @user).notice_user_joining_email.deliver_now # adminへ通知メール
       end
       flash[:notice] = "ログインしました"
       redirect_to user_path(@profile)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -41,7 +41,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private
 
-<<<<<<< HEAD
   def basic_action # line ログイン用メソッドです
     @omniauth = request.env['omniauth.auth']
     if @omniauth.present?
@@ -58,23 +57,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         # redirect_to edit_user_path(@profile.user.id) and return
         UserMailer.with(user: @user).welcome_email.deliver_now
         UserMailer.with(user: @user).notice_user_joining_email.deliver_now
-=======
-    def basic_action # line ログイン用メソッドです
-      @omniauth = request.env['omniauth.auth']
-      if @omniauth.present?
-        @profile = User.where(provider: @omniauth['provider'], uid: @omniauth['uid']).first
-        if @profile
-          @profile.set_values(@omniauth)
-          sign_in(:user, @profile)
-        else
-          @profile = User.new(provider: @omniauth['provider'], uid: @omniauth['uid'])
-          email = @omniauth['info']['email'] ? @omniauth['info']['email'] : "#{@omniauth['uid']}-#{@omniauth['provider']}@example.com"
-          @profile = current_user || User.create!(provider: @omniauth['provider'], uid: @omniauth['uid'], email: email, name: @omniauth['info']['name'], password: Devise.friendly_token[0, 20])
-          @profile.set_values(@omniauth)
-          sign_in(:user, @profile)
-          # redirect_to edit_user_path(@profile.user.id) and return
-        end
->>>>>>> 7d9f3b2e2d8d870ce963c8ab89e5cfafdc2f3b5d
       end
       flash[:notice] = "ログインしました"
       redirect_to user_path(@profile)


### PR DESCRIPTION
## やったこと

* SNSログインでアカウント作成時にadminへ通知メールをpくる

## やらないこと
なし

## できるようになること（ユーザ目線）

* adminが通知メールを受け取る
## できなくなること（ユーザ目線）

* 何ができなくなるのかなし

## 動作確認

* 開発環境でテスト　userのみadminへメール送信成功
## その他

* ownerはメール送信確認できず