### PR TITLE
Feature/Admins#private store ticket buyer list

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -106,6 +106,10 @@ class AdminsController < ApplicationController
     redirect_to admins_private_stores_index_url and return
   end
 
+  def private_store_ticket_buyer_list
+    @private_store_ticket_buyer_list =  User.where.not(issue_ticket_day: nil).where.not(private_store_id: nil).where(use_ticket_day: nil)
+  end
+
   private
 
     def set_user

--- a/app/views/admins/account.html.erb
+++ b/app/views/admins/account.html.erb
@@ -32,6 +32,9 @@
     <div class="account-btn">
       <%= link_to "チケット発券状況", user_have_ticket_path, class: "btn-gradient-3d-simple" %>
     </div></br>
+    <div class="account-btn">
+      <%= link_to "個人店チケット購買者一覧", admins_private_store_ticket_buyer_list_path, class: "btn-gradient-3d-simple" %>
+    </div></br>
     <%
 =begin%>
  <div class="account-btn">

--- a/app/views/admins/private_store_ticket_buyer_list.html.erb
+++ b/app/views/admins/private_store_ticket_buyer_list.html.erb
@@ -12,15 +12,15 @@
           <th>ID</th>
           <th>ユーザー名</th>
           <th>トライアル状態</th>
-	  <th>金額</th>
+          <th>金額</th>
           <th>個人店舗名</th>
-	  <th>オーナ―ID</th>
-	  <th>オーナー名</th>
+          <th>オーナ―ID</th>
+          <th>オーナー名</th>
         </tr>
       </thead>
 
       <% @private_store_ticket_buyer_list.each do |user| %>
-	<% private_store = PrivateStore.find(user.private_store_id) %>
+        <% private_store = PrivateStore.find(user.private_store_id) %>
         <% owner = Owner.find(private_store.owner_id) %>
         <tr>
           <td><%= user.id %></td>
@@ -36,11 +36,10 @@
               -
             <% end %>
           </td>
-	  <td><%= user.price%></td>
+          <td><%= user.price %></td>
           <td><%= private_store.name %> </td>
-	  <td><%= owner.id %></td>
-	  <td><%= owner.name %></td>
-	  <td></td>
+          <td><%= owner.id %></td>
+          <td><%= owner.name %></td>
         </tr>
       <% end %>
     </table>
@@ -52,3 +51,4 @@
   </div>
   <!--%= will_paginate(@private_stores, class: "pagination justify-content-center mt-6 mb-7", renderer: WillPaginate::ActionView::Bootstrap4LinkRenderer) %!-->
 </div>
+

--- a/app/views/admins/private_store_ticket_buyer_list.html.erb
+++ b/app/views/admins/private_store_ticket_buyer_list.html.erb
@@ -1,0 +1,54 @@
+<% provide(:title, '個人店チケット購買者リスト') %>
+
+<p id="notice"><%= notice %></p>
+<div>
+  <h1 class="brand-color display-4 mt-6 mb-6">個人店チケット購買者リスト</h1>
+
+  <div class="col-sm-12">
+
+    <table class="table table-condensed table-hover my-5" id="table-users">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>ユーザー名</th>
+          <th>トライアル状態</th>
+	  <th>金額</th>
+          <th>個人店舗名</th>
+	  <th>オーナ―ID</th>
+	  <th>オーナー名</th>
+        </tr>
+      </thead>
+
+      <% @private_store_ticket_buyer_list.each do |user| %>
+	<% private_store = PrivateStore.find(user.private_store_id) %>
+        <% owner = Owner.find(private_store.owner_id) %>
+        <tr>
+          <td><%= user.id %></td>
+          <td><%= user.name %></td>
+          <td>
+            <% if private_store.admin_private_check == "承認" %>
+              <% if private_store.trial == true && user.select_trial == true %>
+                <%= "参加" %>
+              <% else %>
+                -
+              <% end %>
+            <% else %>
+              -
+            <% end %>
+          </td>
+	  <td><%= user.price%></td>
+          <td><%= private_store.name %> </td>
+	  <td><%= owner.id %></td>
+	  <td><%= owner.name %></td>
+	  <td></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class="private-store-show-btn">
+    <%= link_to account_admin_path, class: "btn btn--blue btn-md btn--shadow" do %>
+      <i class="fas fa-reply"> 戻る</i>
+    <% end %>
+  </div>
+  <!--%= will_paginate(@private_stores, class: "pagination justify-content-center mt-6 mb-7", renderer: WillPaginate::ActionView::Bootstrap4LinkRenderer) %!-->
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,8 @@ Rails.application.routes.draw do
   get "subscriptions/:subscription/prices/:price/subscription_plan", to: "user_plans#subscription_plan", as: :subscription_plan#価格に応じた加盟店のプランへ
   get "private_stores/:private_store/prices/:price/private_store_plan", to: "private_store_user_plans#private_store_plan", as: :private_store_plan#価格に応じた個人店のプランへ
 
-  get "owners/:owners/private_store_ticket_buyer_list", to: "owners#private_store_ticket_buyer_list", as: :private_store_ticket_buyer_list#個人店舗のチケット購買者一覧へ
+  get "owners/:owners/private_store_ticket_buyer_list", to: "owners#private_store_ticket_buyer_list", as: :private_store_ticket_buyer_list#オーナーが見る個人店舗のチケット購買者一覧へ
+  get "admins/private_store_ticket_buyer_list", to: "admins#private_store_ticket_buyer_list", as: :admins_private_store_ticket_buyer_list#管理者が見る個人店舗のチケット購買者一覧へ
 
 
 


### PR DESCRIPTION
## やったこと

管理者が見る個人店舗のチケット購買者一覧を作成しました。

## やらないこと

無し。

## できるようになること（ユーザ目線）

管理者が全ての個人店舗のチケット購買者を把握できるようになる。

## できなくなること（ユーザ目線）

無し。

## 動作確認

違ったオーナ―でチケット発行後、個人店舗のチケット購買者一覧確認。個人店のトライアルプランでチケット発行後、一覧確認。チケット使用後、一覧に表示されないこと。stripe決済後、チケット発行前、一覧に表示されないこと。

## その他

特にありません。